### PR TITLE
Remove "Fully encrypted" Introduction

### DIFF
--- a/draft-netconf-over-quic.xml
+++ b/draft-netconf-over-quic.xml
@@ -78,7 +78,6 @@
       <ul>
         <li>Single connection can be long lived and support multiple NETCONF RPC calls and responses within the same connection, using streams. This is very useful for a network management control station who is regularly monitoring devices and therefore having a long lived connection requires way less resources on both peers.</li>
         <li>1 RTT initial handshake that includes TLS.</li>
-        <li>Fully encrypted</li>
         <li>Adaptable to more difficult environments such as those with long delays(<xref target="I-D.many-deepspace-ip-assessment"/>, <xref target="I-D.huitema-quic-in-space"/>).</li>
       </ul>
       <t>Therefore, QUIC is a proper transport protocol for the secure transport layer of NETCONF. In addition, QUIC does not have the TCP shortcomings such as head of line blocking. This document specifies how to use QUIC as the secure transport protocol for NETCONF.</t>


### PR DESCRIPTION
All contemporary used NETCONF transports are fully encrypted.