### PR TITLE
Use RFC 7589 for server and client identity (authn)

### DIFF
--- a/draft-ietf-netconf-over-quic.xml
+++ b/draft-ietf-netconf-over-quic.xml
@@ -203,13 +203,23 @@ Layer                 Example
     </section>
     <section>
       <name>Endpoint Authentication</name>
+      <t>
+        Since QUIC uses TLS 1.3 this is used to verify server identity and
+        client identity.
+      </t>
       <section>
-        <name>Using QUIC Handshake Authentication</name>
-        <t>NETCONF over QUIC uses QUIC which uses TLS version 1.3 or greater. Therefore, the TLS handshake process can be used for endpoint authentication.</t>
-        <section>
-          <name>Using Third-Party Authentication</name>
-          <t>A third-party authentication mechanism can also be used for endpoint authentication, such as a  TLS client certificate.</t>
-        </section>
+        <name>Server Identity</name>
+        <t>
+          A server's identity MUST be verified according to
+          <xref target="RFC7589" section="6"/>.
+        </t>
+      </section>
+      <section>
+        <name>Client Identity</name>
+        <t>
+          A client's identity MUST be verified according to
+          <xref target="RFC7589" section="7"/>.
+        </t>
       </section>
     </section>
     <section>
@@ -273,7 +283,12 @@ INSERT_TEXT_FROM_FILE(ietf-netconf-quic@YYYY-MM-DD.yang)
     </section>
     <section>
       <name>Security Considerations</name>
-      <t>The security considerations described throughout <xref target="RFC5246"/> and <xref target="RFC6241"/> apply here as well. This document does not require to support third-party authentication (e.g., backend Authentication, Authorization, and Accounting (AAA) servers) due to the fact that TLS does not specify this way of authentication and that NETCONF depends on the transport protocol for the authentication service. If third-party authentication is needed, TLS client certificates or SSH transport can be used. Especially TLS client certificates are recommended to be used here.</t>
+      <t>
+          The security considerations described throughout
+          <xref target="RFC5246"/> and <xref target="RFC6241"/> apply here as
+          well.This document requires verification of server identity and
+          client identity according to <xref target="RFC7589"/>.
+      </t>
       <t>An attacker might be able to inject arbitrary NETCONF messages via some application that does not carefully check exchanged messages deliberately insert the delimiter sequence in a NETCONF message to create a DoS attack.  Hence, applications and NETCONF APIs MUST ensure that the delimiter sequence defined in Section 2.1 never appears in NETCONF messages; otherwise, those messages can be dropped, garbled, or misinterpreted.</t>
       <t>If invalid data or malformed messages are encountered, a robust implementation of this document MUST silently discard the message without further processing and then stop the NETCONF session.</t>
       <t>Finally, this document does not introduce any new security considerations compared to <xref target="RFC6242"/>.</t>
@@ -314,6 +329,7 @@ INSERT_TEXT_FROM_FILE(ietf-netconf-quic@YYYY-MM-DD.yang)
         <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5246.xml"/>
         <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6242.xml"/>
         <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.7301.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.7589.xml"/>
         <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8340.xml"/>
         <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netconf-over-tls13.xml"/>
         <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.many-deepspace-ip-assessment.xml"/>


### PR DESCRIPTION
Leverage RFC 7589 NETCONF over TLS for verifying server and client identity.